### PR TITLE
Fix sending errors with express

### DIFF
--- a/packages/express/src/accountsExpress.js
+++ b/packages/express/src/accountsExpress.js
@@ -19,9 +19,7 @@ const accountsExpress = (AccountsServer) => {
 
   router.use(cors());
 
-  const sendError = (res, err) => (err.serialize
-  ? res.status(500).jsonp(err.serialize().message)
-  : res.status(500).jsonp({ message: err.message }));
+  const sendError = (res, err) => (res.status(500).jsonp({ message: err.message }));
 
   router.use(async (req, res, next) => {
     const accessToken = get(req.headers, 'accounts-access-token', undefined) || get(req.body, 'accessToken', undefined);
@@ -53,9 +51,7 @@ const accountsExpress = (AccountsServer) => {
 
   router.post(`${path}createUser`, async (req, res) => {
     if (AccountsServer.options().forbidClientAccountCreation) {
-      sendError(res, new AccountsError({
-        message: 'Client account creation is forbidden',
-      }));
+      sendError(res, new AccountsError('Client account creation is forbidden'));
     }
     try {
       const user = await AccountsServer.createUser(pick(req.body.user, [


### PR DESCRIPTION
Actually when you make a post request on a endpoint without params this will throw an 500 error. The body the request return is empty.